### PR TITLE
Refactor code, fix block-comment bug, modify parser specifications

### DIFF
--- a/server/routes/parser.js
+++ b/server/routes/parser.js
@@ -8,6 +8,13 @@ module.exports.parse = function(repository) {
         'files': []
     };
 
+    // TODO: make parser compatible to Hdm's node version
+    // TODO: faciliate deletion of block comment end syntax ('*/) by replacing end_index_subtract 
+
+    var push_quests_to_file = function (quests) {
+        file.quests.push(quests);
+    };
+
     for (var f = 0; f < files.length; f++) {
         var lines = files[f].content.split("\n"),
             file = {
@@ -19,43 +26,51 @@ module.exports.parse = function(repository) {
             var line_content = lines[l-1];
 
             if (line_content.indexOf(valid_block_start_syntax) > -1) {
-                if (line_content.indexOf(valid_block_end_syntax) > -1) {
-                    todo_line_parser(l, line_content, 2, 2);
-                } else {
-                    todo_line_parser(l, lines[l], 2, 0);
-                    while (lines[++l].indexOf(valid_block_end_syntax) < 0) {
-                        todo_line_parser(l, lines[l], 0, 0);
+                if (line_content.indexOf(valid_block_start_syntax) < line_content.indexOf(valid_inline_syntax)) {    
+                    if (line_content.indexOf(valid_block_end_syntax) > -1) {
+                        todo_line_parser(file.path, l, line_content, 2, push_quests_to_file);
+                    } else {
+                        todo_line_parser(file.path, l, lines[l], 0, push_quests_to_file);
+                        while (lines[++l].indexOf(valid_block_end_syntax) < 0) {
+                            todo_line_parser(file.path, l, lines[l], 0, push_quests_to_file);
+                        }
+                        todo_line_parser(file.path, l, lines[l], 2, push_quests_to_file);
                     }
-                    todo_line_parser(l, lines[l], 0, 2);
                 }
             } else if (line_content.indexOf(valid_inline_syntax) > -1) {
-                todo_line_parser(l, line_content, 2, 0);
+                todo_line_parser(file.path, l, line_content, 0, push_quests_to_file);
             }
         }
-        parsedRepository.files.push(file);
+        if (file.quests.length > 0){
+            parsedRepository.files.push(file);
+        }
     }
     return parsedRepository;
+}
 
-    function todo_line_parser(line_number, line_content, start_index_addend, end_index_subtract) {
-        var text,
-            regex = /@todo/gi,
-            indices = [];
+function todo_line_parser(filepath, line_number, line_content, end_index_subtract, callback) {
+    var text,
+        regex = /todo/gi,
+        indices = [],
+        quests = [];
 
-        while (result = regex.exec(line_content)) {
-            indices.push(result.index);
+    while (result = regex.exec(line_content)) {
+        indices.push(result.index);
+    }
+
+    for (var i = 0; i < indices.length; i++) {
+        if (i == indices.length - 1){
+            text = line_content.slice(indices[i] + 4, line_content.length - end_index_subtract).trim();
+        } else {
+            text = line_content.slice(indices[i] + 4, indices[i+1]-1).trim();
         }
-
-        for (var i = 0; i < indices.length; i++) {
-            if (i == indices.length - 1){
-                text = line_content.slice(indices[i] + 5 + start_index_addend, line_content.length - end_index_subtract).trim();
-            } else {
-                text = line_content.slice(indices[i] + 5 + start_index_addend, indices[i+1]-1).trim();
-                console.log("else");
-            }
-            file.quests.push({
-                'text': text,
-                'line': file.path + '#L' + line_number
-            });
-        }
+        quests.push({
+            'text': text,
+            'line': filepath + '#L' + line_number
+        });
+        console.log(indices);
+    }
+    if (quests.length > 0) {
+        callback(quests);
     }
 }


### PR DESCRIPTION
parse 'todo:' instead of '@todo' comments, outsource todo_line_parser as
stand-alone function with appropriate callback, only return files
containing quests in the final json, fix undefined-bug at
block-comment's endings
